### PR TITLE
fix: 팀 API 응답 형식 정렬 및 버그 수정

### DIFF
--- a/src/main/java/com/daker/domain/team/controller/TeamController.java
+++ b/src/main/java/com/daker/domain/team/controller/TeamController.java
@@ -60,12 +60,12 @@ public class TeamController {
     }
 
     @DeleteMapping("/{id}")
-    public ApiResponse<Void> deleteTeam(
+    public ApiResponse<java.util.Map<String, String>> deleteTeam(
             @PathVariable Long id,
             @AuthenticationPrincipal Long userId
     ) {
         teamService.deleteTeam(id, userId);
-        return ApiResponse.ok(null);
+        return ApiResponse.ok(java.util.Map.of("message", "팀 모집글이 삭제되었습니다."));
     }
 
     @PostMapping("/{id}/applications")

--- a/src/main/java/com/daker/domain/team/domain/ApplicationStatus.java
+++ b/src/main/java/com/daker/domain/team/domain/ApplicationStatus.java
@@ -1,5 +1,12 @@
 package com.daker.domain.team.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 public enum ApplicationStatus {
-    PENDING, ACCEPTED, REJECTED
+    PENDING, ACCEPTED, REJECTED;
+
+    @JsonCreator
+    public static ApplicationStatus from(String value) {
+        return ApplicationStatus.valueOf(value.toUpperCase());
+    }
 }

--- a/src/main/java/com/daker/domain/team/domain/Team.java
+++ b/src/main/java/com/daker/domain/team/domain/Team.java
@@ -71,9 +71,9 @@ public class Team {
         return this.members.size() >= maxTeamSize;
     }
 
-    public void update(String name, String description, boolean isOpen) {
-        this.name = name;
-        this.description = description;
-        this.isOpen = isOpen;
+    public void update(String name, String description, Boolean isOpen) {
+        if (name != null) this.name = name;
+        if (description != null) this.description = description;
+        if (isOpen != null) this.isOpen = isOpen;
     }
 }

--- a/src/main/java/com/daker/domain/team/dto/TeamDetailResponse.java
+++ b/src/main/java/com/daker/domain/team/dto/TeamDetailResponse.java
@@ -2,6 +2,7 @@ package com.daker.domain.team.dto;
 
 import com.daker.domain.team.domain.Team;
 import com.daker.domain.team.domain.TeamMember;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 
 import java.util.List;
@@ -13,6 +14,7 @@ public class TeamDetailResponse {
     private final Long hackathonId;
     private final String name;
     private final String description;
+    @JsonProperty("isOpen")
     private final boolean isOpen;
     private final TeamSummaryResponse.LeaderInfo leader;
     private final List<MemberInfo> members;

--- a/src/main/java/com/daker/domain/team/dto/TeamSummaryResponse.java
+++ b/src/main/java/com/daker/domain/team/dto/TeamSummaryResponse.java
@@ -1,6 +1,7 @@
 package com.daker.domain.team.dto;
 
 import com.daker.domain.team.domain.Team;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 
 @Getter
@@ -10,6 +11,7 @@ public class TeamSummaryResponse {
     private final Long hackathonId;
     private final String name;
     private final String description;
+    @JsonProperty("isOpen")
     private final boolean isOpen;
     private final int memberCount;
     private final LeaderInfo leader;

--- a/src/main/java/com/daker/domain/team/dto/TeamUpdateRequest.java
+++ b/src/main/java/com/daker/domain/team/dto/TeamUpdateRequest.java
@@ -1,17 +1,13 @@
 package com.daker.domain.team.dto;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 @Getter
 public class TeamUpdateRequest {
 
-    @NotBlank
     private String name;
 
     private String description;
 
-    @NotNull
     private Boolean isOpen;
 }

--- a/src/main/java/com/daker/domain/team/repository/TeamApplicationRepository.java
+++ b/src/main/java/com/daker/domain/team/repository/TeamApplicationRepository.java
@@ -14,4 +14,6 @@ public interface TeamApplicationRepository extends JpaRepository<TeamApplication
     Optional<TeamApplication> findByTeamIdAndUserId(Long teamId, Long userId);
 
     boolean existsByTeamIdAndUserIdAndStatus(Long teamId, Long userId, ApplicationStatus status);
+
+    void deleteAllByTeamId(Long teamId);
 }

--- a/src/main/java/com/daker/domain/team/service/TeamService.java
+++ b/src/main/java/com/daker/domain/team/service/TeamService.java
@@ -120,6 +120,8 @@ public class TeamService {
             throw new CustomException(ErrorCode.TEAM_APPLICATION_CLOSED);
         }
 
+        teamApplicationRepository.deleteAllByTeamId(teamId);
+
         registrationRepository.findByTeamId(teamId)
                 .ifPresent(registrationRepository::delete);
 


### PR DESCRIPTION
- TeamSummaryResponse, TeamDetailResponse: isOpen boolean @JsonProperty("isOpen") 추가
- TeamUpdateRequest: name @NotBlank 제거, isOpen @NotNull 제거 → 부분 수정 지원
- Team.update(): null 필드는 기존 값 유지하도록 변경
- TeamApplicationRepository: deleteAllByTeamId 추가 (팀 삭제 시 FK 오류 수정)
- TeamService: deleteTeam 시 팀 신청 먼저 삭제
- TeamController: deleteTeam 메시지 응답 추가
- ApplicationStatus: @JsonCreator 추가 (대소문자 무관 처리)