### PR TITLE
fix: 해커톤 API 응답 형식 명세서 기준으로 정렬

### DIFF
--- a/src/main/java/com/daker/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/daker/domain/auth/controller/AuthController.java
@@ -33,9 +33,9 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
-    public ApiResponse<Void> logout(@AuthenticationPrincipal Long userId) {
+    public ApiResponse<java.util.Map<String, String>> logout(@AuthenticationPrincipal Long userId) {
         authService.logout(userId);
-        return ApiResponse.ok(null);
+        return ApiResponse.ok(java.util.Map.of("message", "로그아웃 되었습니다."));
     }
 
     @GetMapping("/me")

--- a/src/main/java/com/daker/domain/hackathon/controller/HackathonController.java
+++ b/src/main/java/com/daker/domain/hackathon/controller/HackathonController.java
@@ -45,12 +45,12 @@ public class HackathonController {
     }
 
     @DeleteMapping("/{id}/register")
-    public ApiResponse<Void> cancelRegistration(
+    public ApiResponse<java.util.Map<String, String>> cancelRegistration(
             @PathVariable Long id,
             @AuthenticationPrincipal Long userId
     ) {
         hackathonService.cancelRegistration(id, userId);
-        return ApiResponse.ok(null);
+        return ApiResponse.ok(java.util.Map.of("message", "참가 신청이 취소되었습니다."));
     }
 
     @GetMapping("/{id}/teams")

--- a/src/main/java/com/daker/domain/hackathon/dto/LeaderboardResponse.java
+++ b/src/main/java/com/daker/domain/hackathon/dto/LeaderboardResponse.java
@@ -8,26 +8,26 @@ import java.util.List;
 @Getter
 public class LeaderboardResponse {
 
-    private final boolean public_;
-    private final List<LeaderboardTeamInfo> teams;
+    private final String scoreType;
+    private final List<LeaderboardTeamInfo> items;
 
-    public LeaderboardResponse(boolean isPublic, List<LeaderboardTeamInfo> teams) {
-        this.public_ = isPublic;
-        this.teams = teams;
+    public LeaderboardResponse(String scoreType, List<LeaderboardTeamInfo> items) {
+        this.scoreType = scoreType;
+        this.items = items;
     }
 
     @Getter
     public static class LeaderboardTeamInfo {
-        private final Long teamId;
+        private final Integer rank;
         private final String teamName;
-        private final int memberCount;
-        private final Double totalScore; // 공개 전 null
+        private final Double score;
+        private final boolean submitted;
 
-        public LeaderboardTeamInfo(Team team, Double totalScore) {
-            this.teamId = team.getId();
+        public LeaderboardTeamInfo(Team team, Integer rank, Double score, boolean submitted) {
+            this.rank = rank;
             this.teamName = team.getName();
-            this.memberCount = team.getMembers().size();
-            this.totalScore = totalScore;
+            this.score = score;
+            this.submitted = submitted;
         }
     }
 }

--- a/src/main/java/com/daker/domain/hackathon/dto/RegistrationStatusResponse.java
+++ b/src/main/java/com/daker/domain/hackathon/dto/RegistrationStatusResponse.java
@@ -8,15 +8,29 @@ import java.time.LocalDateTime;
 @Getter
 public class RegistrationStatusResponse {
 
-    private final Long hackathonId;
+    private final boolean registered;
+    private final Long registrationId;
     private final Long teamId;
     private final String teamName;
     private final LocalDateTime registeredAt;
 
     public RegistrationStatusResponse(HackathonRegistration registration) {
-        this.hackathonId = registration.getHackathon().getId();
+        this.registered = true;
+        this.registrationId = registration.getId();
         this.teamId = registration.getTeam().getId();
         this.teamName = registration.getTeam().getName();
         this.registeredAt = registration.getRegisteredAt();
+    }
+
+    public static RegistrationStatusResponse notRegistered() {
+        return new RegistrationStatusResponse();
+    }
+
+    private RegistrationStatusResponse() {
+        this.registered = false;
+        this.registrationId = null;
+        this.teamId = null;
+        this.teamName = null;
+        this.registeredAt = null;
     }
 }

--- a/src/main/java/com/daker/domain/hackathon/service/HackathonService.java
+++ b/src/main/java/com/daker/domain/hackathon/service/HackathonService.java
@@ -63,15 +63,12 @@ public class HackathonService {
         hackathonRepository.findByIdAndDeletedFalse(hackathonId)
                 .orElseThrow(() -> new CustomException(ErrorCode.HACKATHON_NOT_FOUND));
 
-        Team myTeam = teamRepository.findAllByUserId(userId).stream()
+        return teamRepository.findAllByUserId(userId).stream()
                 .filter(t -> t.getHackathon().getId().equals(hackathonId))
                 .findFirst()
-                .orElseThrow(() -> new CustomException(ErrorCode.REGISTRATION_NOT_FOUND));
-
-        HackathonRegistration registration = registrationRepository.findByTeamId(myTeam.getId())
-                .orElseThrow(() -> new CustomException(ErrorCode.REGISTRATION_NOT_FOUND));
-
-        return new RegistrationStatusResponse(registration);
+                .flatMap(t -> registrationRepository.findByTeamId(t.getId()))
+                .map(RegistrationStatusResponse::new)
+                .orElse(RegistrationStatusResponse.notRegistered());
     }
 
     @Transactional
@@ -113,12 +110,12 @@ public class HackathonService {
                 .orElseThrow(() -> new CustomException(ErrorCode.HACKATHON_NOT_FOUND));
 
         List<Team> teams = teamRepository.findAllByHackathonId(hackathonId);
-        boolean isEnded = hackathon.isEnded();
 
-        List<LeaderboardResponse.LeaderboardTeamInfo> teamInfos = teams.stream()
-                .map(team -> new LeaderboardResponse.LeaderboardTeamInfo(team, isEnded ? null : null))
+        // TODO: 제출 도메인 개발 후 submitted 여부 및 score 연결
+        List<LeaderboardResponse.LeaderboardTeamInfo> items = teams.stream()
+                .map(team -> new LeaderboardResponse.LeaderboardTeamInfo(team, null, null, false))
                 .toList();
 
-        return new LeaderboardResponse(isEnded, teamInfos);
+        return new LeaderboardResponse(hackathon.getScoreType().name(), items);
     }
 }

--- a/src/test/java/com/daker/domain/hackathon/HackathonServiceTest.java
+++ b/src/test/java/com/daker/domain/hackathon/HackathonServiceTest.java
@@ -203,16 +203,17 @@ class HackathonServiceTest {
     }
 
     @Test
-    @DisplayName("해당 해커톤에 팀이 없으면 등록 상태 조회 예외")
-    void getRegistrationStatus_teamNotFound() {
+    @DisplayName("해당 해커톤에 팀이 없으면 미신청 상태 반환")
+    void getRegistrationStatus_notRegistered() {
         Hackathon h = mockOpenHackathon();
         given(hackathonRepository.findByIdAndDeletedFalse(1L)).willReturn(Optional.of(h));
         given(teamRepository.findAllByUserId(1L)).willReturn(List.of());
 
-        assertThatThrownBy(() -> hackathonService.getRegistrationStatus(1L, 1L))
-                .isInstanceOf(CustomException.class)
-                .extracting(e -> ((CustomException) e).getErrorCode())
-                .isEqualTo(ErrorCode.REGISTRATION_NOT_FOUND);
+        RegistrationStatusResponse response = hackathonService.getRegistrationStatus(1L, 1L);
+
+        assertThat(response.isRegistered()).isFalse();
+        assertThat(response.getRegistrationId()).isNull();
+        assertThat(response.getTeamId()).isNull();
     }
 
     // -------------------------------------------------------------------------
@@ -269,8 +270,8 @@ class HackathonServiceTest {
     // -------------------------------------------------------------------------
 
     @Test
-    @DisplayName("진행 중인 해커톤 리더보드 조회 - 점수 비공개")
-    void getLeaderboard_ongoing() {
+    @DisplayName("리더보드 조회 - 미제출 팀 포함")
+    void getLeaderboard_notSubmitted() {
         Hackathon h = mockOpenHackathon();
         User leader = mockUser(1L);
         Team team = mockTeam(1L, h, leader);
@@ -280,23 +281,21 @@ class HackathonServiceTest {
 
         LeaderboardResponse response = hackathonService.getLeaderboard(1L);
 
-        assertThat(response.isPublic_()).isFalse();
-        assertThat(response.getTeams()).hasSize(1);
+        assertThat(response.getItems()).hasSize(1);
+        assertThat(response.getItems().get(0).isSubmitted()).isFalse();
+        assertThat(response.getItems().get(0).getScore()).isNull();
     }
 
     @Test
-    @DisplayName("종료된 해커톤 리더보드 조회 - 점수 공개")
-    void getLeaderboard_ended() {
-        Hackathon h = mockEndedHackathon();
-        User leader = mockUser(1L);
-        Team team = mockTeam(1L, h, leader);
+    @DisplayName("리더보드 조회 - scoreType 포함")
+    void getLeaderboard_scoreType() {
+        Hackathon h = mockOpenHackathon();
+        given(hackathonRepository.findByIdAndDeletedFalse(1L)).willReturn(Optional.of(h));
+        given(teamRepository.findAllByHackathonId(1L)).willReturn(List.of());
 
-        given(hackathonRepository.findByIdAndDeletedFalse(2L)).willReturn(Optional.of(h));
-        given(teamRepository.findAllByHackathonId(2L)).willReturn(List.of(team));
+        LeaderboardResponse response = hackathonService.getLeaderboard(1L);
 
-        LeaderboardResponse response = hackathonService.getLeaderboard(2L);
-
-        assertThat(response.isPublic_()).isTrue();
+        assertThat(response.getScoreType()).isEqualTo("SCORE");
     }
 
     @Test


### PR DESCRIPTION
- RegistrationStatusResponse: registered/registrationId 필드 추가, 미신청 시 notRegistered() 반환
- LeaderboardResponse: scoreType, items 구조로 재편 (teams → items, totalScore → score)
- HackathonService: getRegistrationStatus 404 → 200(notRegistered) 변경
- HackathonController: cancelRegistration 메시지 응답 추가
- AuthController: logout 메시지 응답 추가
- HackathonServiceTest: 변경된 응답 형식에 맞게 테스트 수정